### PR TITLE
Add Flight Guard AI protocol skeleton and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # deep-lambda
-mesh communication framework and protocol
+
+Flight Guard AI provides a secure inter-aircraft mesh communication framework.
+See [docs/flight_guard_ai.md](docs/flight_guard_ai.md) for protocol and hardware details.

--- a/docs/flight_guard_ai.md
+++ b/docs/flight_guard_ai.md
@@ -1,0 +1,40 @@
+# Flight Guard AI Mesh Protocol
+
+## Overview
+
+Flight Guard AI defines a secure inter-aircraft mesh network that allows aircraft to relay
+telemetry and voice data when satellite links are unavailable. Every aircraft runs the
+same software stack and can act as an emitter or receiver.
+
+## Hardware Requirements
+
+- **CPU**: ARM Cortex-A53/A72 or comparable RISC-V (1–2 GHz) with NEON extensions
+- **Memory**: 2 GB or more of ECC RAM
+- **Security**: Hardware TPM or HSM for key storage, optional crypto acceleration
+- **Networking**: Redundant Ethernet or avionics-grade Wi-Fi/mesh radio
+- **RTOS**: seL4, QNX, or RTEMS with Rust/Python cross-compilation support
+
+## Module Functionality
+
+| Module          | Purpose |
+|-----------------|---------|
+| `identity.py`   | Loads keys, holds certificates, and signs messages |
+| `handshake.py`  | Establishes session keys via Noise/DTLS handshakes |
+| `crypto.py`     | Provides AEAD encryption/decryption helpers |
+| `packets.py`    | Defines ping, pong, data relay, and ack packet structures |
+| `relay.py`      | Maintains neighbor state and forwards packets |
+| `node.py`       | Application entry point tying all pieces together |
+
+## Protocol Highlights
+
+1. **Ping/Pong**: Aircraft announce presence with signed pings.
+2. **Wellness Check**: A receiving aircraft verifies the signature and responds with a pong.
+3. **Data Relay**: When satellite connectivity is lost, packets with four encrypted sections
+   (audio, data log, and two decoys) are relayed through the mesh. Each header includes a
+   unique payload hash and timestamp.
+4. **Acknowledgment**: Each relay returns an ACK containing the payload hash and the
+   measured time-of-flight in milliseconds.
+5. **Adaptive Routing**: If time-of-flight increases, nodes initiate ping sweeps to locate
+   nearer neighbors while continuing transmission.
+
+All timestamps are expressed in UTC to keep logs consistent.

--- a/flight_guard_ai/crypto.py
+++ b/flight_guard_ai/crypto.py
@@ -1,0 +1,15 @@
+"""Cryptographic helper functions."""
+from typing import Tuple
+
+
+def encrypt(key: bytes, nonce: bytes, plaintext: bytes) -> Tuple[bytes, bytes]:
+    """Encrypt data using an AEAD cipher.
+
+    Returns a tuple of (ciphertext, tag). This is a stub implementation.
+    """
+    raise NotImplementedError("Encryption not implemented")
+
+
+def decrypt(key: bytes, nonce: bytes, ciphertext: bytes, tag: bytes) -> bytes:
+    """Decrypt data using an AEAD cipher."""
+    raise NotImplementedError("Decryption not implemented")

--- a/flight_guard_ai/handshake.py
+++ b/flight_guard_ai/handshake.py
@@ -1,0 +1,15 @@
+"""Handshake routines using Noise protocol patterns."""
+from dataclasses import dataclass
+
+
+@dataclass
+class HandshakeResult:
+    session_key: bytes
+
+
+def initiate_handshake(identity, peer_public_key: bytes) -> HandshakeResult:
+    """Perform an authenticated key exchange.
+
+    This function is a placeholder for a Noise or DTLS-based handshake.
+    """
+    raise NotImplementedError("Handshake not implemented")

--- a/flight_guard_ai/identity.py
+++ b/flight_guard_ai/identity.py
@@ -1,0 +1,25 @@
+"""Identity management for Flight Guard AI.
+
+Handles key generation/loading and certificate validation.
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Identity:
+    """Represents an aircraft cryptographic identity."""
+    private_key: bytes
+    certificate: bytes
+
+    def sign(self, message: bytes) -> bytes:
+        """Sign a message using the private key.
+
+        In a production system this would delegate to an HSM/TPM.
+        """
+        raise NotImplementedError("Signing not implemented")
+
+    @staticmethod
+    def verify_peer(cert: bytes) -> bool:
+        """Verify a peer certificate against the revocation list."""
+        raise NotImplementedError("Peer verification not implemented")

--- a/flight_guard_ai/node.py
+++ b/flight_guard_ai/node.py
@@ -1,0 +1,8 @@
+"""Main event loop tying together handshake, relay, and packet I/O."""
+from .identity import Identity
+from .relay import RelayNode
+
+
+def main() -> None:
+    """Entry point for the Flight Guard AI node."""
+    raise NotImplementedError("Event loop not implemented")

--- a/flight_guard_ai/packets.py
+++ b/flight_guard_ai/packets.py
@@ -1,0 +1,54 @@
+"""Packet structures for Flight Guard AI."""
+from __future__ import annotations
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Tuple
+import hashlib
+
+SECTION_SIZE = 4096
+
+
+class MessageType(Enum):
+    PING = 0x01
+    PONG = 0x02
+    DATA_RELAY = 0x03
+    ACK = 0x04
+
+
+@dataclass
+class RelayPathEntry:
+    aircraft_id: bytes
+    hop_number: int
+
+
+@dataclass
+class DataBody:
+    """Four encrypted sections: audio, log, and two decoys."""
+    audio_enc: bytes = field(default_factory=lambda: b"".ljust(SECTION_SIZE, b"\x00"))
+    log_enc: bytes = field(default_factory=lambda: b"".ljust(SECTION_SIZE, b"\x00"))
+    decoy1_enc: bytes = field(default_factory=lambda: b"".ljust(SECTION_SIZE, b"\x00"))
+    decoy2_enc: bytes = field(default_factory=lambda: b"".ljust(SECTION_SIZE, b"\x00"))
+
+
+@dataclass
+class DataRelayHeader:
+    message_type: MessageType
+    timestamp_utc: int
+    payload_hash: bytes
+    relay_path: List[RelayPathEntry] = field(default_factory=list)
+
+
+@dataclass
+class DataPacket:
+    header: DataRelayHeader
+    body: DataBody
+
+    def calc_hash(self) -> bytes:
+        """Return a BLAKE2s hash over header and body."""
+        h = hashlib.blake2s()
+        h.update(str(self.header).encode())
+        h.update(self.body.audio_enc)
+        h.update(self.body.log_enc)
+        h.update(self.body.decoy1_enc)
+        h.update(self.body.decoy2_enc)
+        return h.digest()

--- a/flight_guard_ai/relay.py
+++ b/flight_guard_ai/relay.py
@@ -1,0 +1,27 @@
+"""Relay logic for forwarding packets between aircraft."""
+from dataclasses import dataclass, field
+from typing import Dict
+from .packets import DataPacket, RelayPathEntry, MessageType
+
+
+@dataclass
+class NeighborInfo:
+    last_seen: int
+    rtt_ms: int
+
+
+@dataclass
+class RelayNode:
+    neighbors: Dict[bytes, NeighborInfo] = field(default_factory=dict)
+
+    def handle_packet(self, pkt: DataPacket) -> None:
+        """Process an incoming packet and forward or deliver."""
+        raise NotImplementedError("Relay logic not implemented")
+
+    def send_ack(self, payload_hash: bytes, tof_ms: int) -> None:
+        """Send an acknowledgment for a received packet."""
+        raise NotImplementedError("ACK send not implemented")
+
+    def monitor_latency(self) -> None:
+        """Check time-of-flight and seek better neighbors if needed."""
+        raise NotImplementedError("Latency monitoring not implemented")


### PR DESCRIPTION
## Summary
- scaffold Flight Guard AI modules for identity, handshake, packet handling, crypto helpers, relaying, and node entry point
- document mesh protocol, hardware requirements, and module roles
- add gitignore for Python artifacts

## Testing
- `python -m py_compile flight_guard_ai/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3c6cca19083289b97e38d175efaa9